### PR TITLE
Added feature to change the luminosity function based on RA, Dec

### DIFF
--- a/docs/custom-transients.rst
+++ b/docs/custom-transients.rst
@@ -71,7 +71,11 @@ default values are acceptable for the simulation.
 
 The function can further have any number of keyword argument, values
 for which can be provided as a dictionary as shown in the example
-below.
+below. In addition to the redshifts and the ``sncosmo.Model``, the
+function will also receive RA and Dec as keyword arguments, e.g. for
+simulations of gravitationally lensed SNe. Unless the keyword aruments
+``ra`` and ``dec`` are used by this function, it will always require
+``**kwargs`` as an argument in its definition.
 
 Using a Sky Map for Coordinate Generation
 =========================================

--- a/simsurvey/simultarget.py
+++ b/simsurvey/simultarget.py
@@ -642,6 +642,7 @@ class TransientGenerator( BaseObject ):
         if "lightcurve_prop" in self.transient_coverage.keys():
             lc = self.transient_coverage["lightcurve_prop"]
             param = lc["param_func"](self.zcmb,self.model,
+                                     ra=self.ra, dec=self.dec,
                                      **lc["param_func_kwargs"])
             self._derived_properties["simul_parameters"]["lightcurve"] = param 
 
@@ -1278,7 +1279,7 @@ class LightCurveGenerator( _PropertyGenerator_ ):
                                   color_mean=0, color_sigma=0.1,
                                   stretch_mean=0, stretch_sigma=1,
                                   alpha=0.13, beta=3.,
-                                  cosmo=Planck15):
+                                  cosmo=Planck15, **kwargs):
         """
         """
         ntransient = len(redshifts)
@@ -1303,7 +1304,7 @@ class LightCurveGenerator( _PropertyGenerator_ ):
                                       color_mean=0, color_sigma=0.1,
                                       stretch_mean=(0.5, -1), stretch_sigma=(1, 1),
                                       stretch_thr=0.75, alpha=0, beta=3,
-                                      cosmo=Planck15):
+                                      cosmo=Planck15, **kwargs):
         """
         stretch parameters assume bimodal distribution
         stretch_thr is a threshold for uniformly drawn number used to determine 

--- a/simsurvey/version.py
+++ b/simsurvey/version.py
@@ -1,1 +1,1 @@
-__VERSION__ = "0.7.0.dev1"
+__VERSION__ = "0.7.0.dev2"


### PR DESCRIPTION
For some use cases, e.g. magnification of SNe by gravitational lenses,
the luminosity function of the transient needs to be aware of the
coordinates of the transient. Previously this information had not been
passed to it. This commit add RA and Dec as keyword arguments to be
passed to the function drawing the LC parameters from the luminosity
function etc. Because of this the function definition must now either
include `ra` and `dec` as arguments or use `**kwargs` to catch them.